### PR TITLE
[affiliates_bloginfo] and added 'current' to [affiliates_url]

### DIFF
--- a/affiliates.php
+++ b/affiliates.php
@@ -21,7 +21,7 @@
  * Plugin Name: Affiliates
  * Plugin URI: http://www.itthinx.com/plugins/affiliates
  * Description: The Affiliates plugin provides the right tools to maintain a partner referral program.
- * Version: 2.15.5
+ * Version: 2.15.6
  * Author: itthinx
  * Author URI: http://www.itthinx.com
  * Donate-Link: http://www.itthinx.com
@@ -30,7 +30,7 @@
  * License: GPLv3
  */
 if ( !defined( 'AFFILIATES_CORE_VERSION' ) ) {
-	define( 'AFFILIATES_CORE_VERSION', '2.15.5' );
+	define( 'AFFILIATES_CORE_VERSION', '2.15.6' );
 	define( 'AFFILIATES_PLUGIN_NAME', 'affiliates' );
 	define( 'AFFILIATES_FILE', __FILE__ );
 	define( 'AFFILIATES_PLUGIN_BASENAME', plugin_basename( AFFILIATES_FILE ) );

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 == Affiliates - Changelog ==
 
+= 2.15.6 =
+* Added the [affiliates_bloginfo] shortcode.
+* Extended the functionality provided by the [affiliates_url] shortcode adding the 'current' attribute for get the current page url.
+
 = 2.15.5 =
 * Added affiliates delete bulk option.
 * For WordPress translation : Added Text Domain and Domain Path header tags.

--- a/lib/core/class-affiliates-shortcodes.php
+++ b/lib/core/class-affiliates-shortcodes.php
@@ -50,6 +50,7 @@ class Affiliates_Shortcodes {
 		add_shortcode( 'affiliates_logout', array( __CLASS__, 'affiliates_logout' ) );
 		add_shortcode( 'affiliates_fields', array( __CLASS__, 'affiliates_fields' ) );
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'wp_enqueue_scripts' ) );
+		add_shortcode( 'affiliates_bloginfo', array( __CLASS__, 'affiliates_bloginfo' ) );
 	}
 
 	/**
@@ -695,7 +696,15 @@ class Affiliates_Shortcodes {
 	 * @param string $content (is not used)
 	 */
 	public static function affiliates_url( $atts, $content = null ) {
-		global $wpdb;
+		global $wpdb, $wp;
+
+		$options = shortcode_atts(
+			array(
+				'current'  => null
+			),
+			$atts
+		);
+		extract( $options );
 
 		remove_shortcode( 'affiliates_url' );
 		$content = do_shortcode( $content );
@@ -711,7 +720,10 @@ class Affiliates_Shortcodes {
 				intval( $user_id )
 			))) {
 				if ( strlen( $content ) == 0 ) {
-					$base_url = get_bloginfo( 'url' );
+					$url = get_bloginfo( 'url' );
+					if ( $current !== null ) {
+						$url = get_permalink();
+					}
 				} else {
 					// wp_texturize() has already been applied to $content and
 					// it indiscriminately replaces ampersands with the HTML
@@ -719,13 +731,13 @@ class Affiliates_Shortcodes {
 					// are not messed up. Note that it does that even though we
 					// have indicated to exclude affiliates_url via the
 					// no_texturize_shortcodes filter.
-					$base_url = trim( $content );
-					$base_url = str_replace( '&#038;', '&', $base_url );
-					$base_url = strip_tags( $base_url );
-					$base_url = preg_replace('/\r|\n/', '', $base_url );
-					$base_url = trim( $base_url );
+					$url = trim( $content );
+					$url = str_replace( '&#038;', '&', $url );
+					$url = strip_tags( $url );
+					$url = preg_replace('/\r|\n/', '', $url );
+					$url = trim( $url );
 				}
-				$output .= affiliates_get_affiliate_url( $base_url, $affiliate_id );
+				$output .= affiliates_get_affiliate_url( $url, $affiliate_id );
 			}
 		}
 		return $output;
@@ -998,6 +1010,30 @@ class Affiliates_Shortcodes {
 			}
 		}
 		return $output;
+	}
+
+	/**
+	 * Bloginfo shortcode - renders the blog info.
+	 * 
+	 * key - Site info to retrieve. Default empty (site name).
+	 * filter - How to filter what is retrieved.
+	 * 
+	 * @param array $atts attributes
+	 * @param string $content not used
+	 */
+	public static function affiliates_bloginfo( $atts, $content = null ) {
+
+		$output = "";
+		$options = shortcode_atts(
+			array(
+				'key'  => "",
+				'filter'  => 'raw'
+			),
+			$atts
+		);
+		extract( $options );
+
+		return get_bloginfo( $key, $filter );
 	}
 }
 Affiliates_Shortcodes::init();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://www.itthinx.com/plugins/affiliates
 Tags: ads, AddToAny, AddThis, advertising, affiliate, affiliate marketing, affiliate plugin, affiliate tool, affiliates, contact form, contact form 7, downloads, e-commerce, Ecwid, Events Manager, Jigoshop, lead, link, marketing, money, partner, Pay per Click, PayPal, PPC, referral, referral links, referrer, sales, shopping cart, TheCartPress, track, transaction, WooCommerce, WP e-Commerce
 Requires at least: 4.0.0
 Tested up to: 4.5.3
-Stable tag: 2.15.5
+Stable tag: 2.15.6
 License: GPLv3
 
 The Affiliates system provides powerful tools to maintain an Affiliate Marketing Program.
@@ -340,6 +340,10 @@ See [Affiliates Screenshots](http://www.itthinx.com/plugins/affiliates/affiliate
 
 == Changelog ==
 
+= 2.15.6 =
+* Added the [affiliates_bloginfo] shortcode.
+* Extended the functionality provided by the [affiliates_url] shortcode adding the 'current' attribute for get the current page url.
+
 = 2.15.5 =
 * Added affiliates delete bulk option.
 * For WordPress translation : Added Text Domain and Domain Path header tags.
@@ -370,6 +374,6 @@ See [Affiliates Screenshots](http://www.itthinx.com/plugins/affiliates/affiliate
 
 == Upgrade Notice ==
 
-= 2.15.5 =
-* Added affiliates delete bulk option.
-* For WordPress translation : Added Text Domain and Domain Path header tags.
+= 2.15.6 =
+* Added the [affiliates_bloginfo] shortcode.
+* Extended the functionality provided by the [affiliates_url] shortcode adding the 'current' attribute for get the current page url.


### PR DESCRIPTION
* Added the [affiliates_bloginfo] shortcode.
* Extended the functionality provided by the [affiliates_url] shortcode
adding the 'current' attribute for get the current page url.