### PR TITLE
Added the [affiliates_user] shortcode

### DIFF
--- a/affiliates.php
+++ b/affiliates.php
@@ -21,7 +21,7 @@
  * Plugin Name: Affiliates
  * Plugin URI: http://www.itthinx.com/plugins/affiliates
  * Description: The Affiliates plugin provides the right tools to maintain a partner referral program.
- * Version: 2.15.6
+ * Version: 2.15.7
  * Author: itthinx
  * Author URI: http://www.itthinx.com
  * Donate-Link: http://www.itthinx.com
@@ -30,7 +30,7 @@
  * License: GPLv3
  */
 if ( !defined( 'AFFILIATES_CORE_VERSION' ) ) {
-	define( 'AFFILIATES_CORE_VERSION', '2.15.6' );
+	define( 'AFFILIATES_CORE_VERSION', '2.15.7' );
 	define( 'AFFILIATES_PLUGIN_NAME', 'affiliates' );
 	define( 'AFFILIATES_FILE', __FILE__ );
 	define( 'AFFILIATES_PLUGIN_BASENAME', plugin_basename( AFFILIATES_FILE ) );

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Affiliates - Changelog ==
 
+= 2.15.7 =
+* Added the [affiliates_user] shortcode which allows to render user meta data info if the user is an affiliate.
+
 = 2.15.6 =
 * Added the [affiliates_bloginfo] shortcode.
 * Extended the functionality provided by the [affiliates_url] shortcode adding the 'url' attribute.

--- a/lib/core/class-affiliates-settings.php
+++ b/lib/core/class-affiliates-settings.php
@@ -232,7 +232,7 @@ class Affiliates_Settings {
 	/**
 	 * Outputs a note to confirm settings have been saved.
 	 */
-	protected static function settings_saved_notice() {
+	public static function settings_saved_notice() {
 		echo '<div class="updated">';
 		echo __( 'Settings saved.', 'affiliates' );
 		echo '</div>';

--- a/lib/core/class-affiliates-shortcodes.php
+++ b/lib/core/class-affiliates-shortcodes.php
@@ -51,6 +51,7 @@ class Affiliates_Shortcodes {
 		add_shortcode( 'affiliates_fields', array( __CLASS__, 'affiliates_fields' ) );
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'wp_enqueue_scripts' ) );
 		add_shortcode( 'affiliates_bloginfo', array( __CLASS__, 'affiliates_bloginfo' ) );
+		add_shortcode( 'affiliates_user', array( __CLASS__, 'affiliates_user' ) );
 	}
 
 	/**
@@ -1044,6 +1045,37 @@ class Affiliates_Shortcodes {
 		extract( $options );
 
 		return esc_html( get_bloginfo( $key ) );
+	}
+
+	/**
+	 * affiliates_user shortcode - renders user meta of the current affiliate.
+	 *
+	 * key - User meta info to retrieve. Default empty.
+	 *
+	 * @param array $atts attributes
+	 * @param string $content not used
+	 */
+	public static function affiliates_user( $atts, $content = null ) {
+	
+		$output = "";
+		$options = shortcode_atts(
+				array(
+						'key'  => ''
+				),
+				$atts
+				);
+		extract( $options );
+	
+		$output = "";
+		if ( is_user_logged_in() && ( $key !== '' ) ) {
+			$user_id = get_current_user_id();
+			$user = get_user_by( 'id', $user_id );
+			if ( affiliates_user_is_affiliate( $user_id ) ) {
+				$output .= get_user_meta( $user_id, $key, true );
+			}
+		}
+	
+		return esc_html( $output );
 	}
 }
 Affiliates_Shortcodes::init();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://www.itthinx.com/plugins/affiliates
 Tags: ads, AddToAny, AddThis, advertising, affiliate, affiliate marketing, affiliate plugin, affiliate tool, affiliates, contact form, contact form 7, downloads, e-commerce, Ecwid, Events Manager, Jigoshop, lead, link, marketing, money, partner, Pay per Click, PayPal, PPC, referral, referral links, referrer, sales, shopping cart, TheCartPress, track, transaction, WooCommerce, WP e-Commerce
 Requires at least: 4.0.0
 Tested up to: 4.5.3
-Stable tag: 2.15.6
+Stable tag: 2.15.7
 License: GPLv3
 
 The Affiliates system provides powerful tools to maintain an Affiliate Marketing Program.
@@ -340,6 +340,9 @@ See [Affiliates Screenshots](http://www.itthinx.com/plugins/affiliates/affiliate
 
 == Changelog ==
 
+= 2.15.7 =
+* Added the [affiliates_user] shortcode which allows to render user meta data info if the user is an affiliate.
+
 = 2.15.6 =
 * Added the [affiliates_bloginfo] shortcode.
 * Extended the functionality provided by the [affiliates_url] shortcode adding the 'url' attribute.
@@ -374,5 +377,5 @@ See [Affiliates Screenshots](http://www.itthinx.com/plugins/affiliates/affiliate
 
 == Upgrade Notice ==
 
-= 2.15.6 =
-* This release adds new and extends existing shortcodes.
+= 2.15.7 =
+* Added the [affiliates_user] shortcode which allows to render user meta data info if the user is an affiliate.


### PR DESCRIPTION
- Added the [affiliates_user] shortcode.
- Changed the ‘settings_saved_notice’ visibility to public. We need
this to add saved notices on Settings->Commissions.