### PR TITLE
Fixed the affiliates_is_not_referred shortcode

### DIFF
--- a/affiliates.php
+++ b/affiliates.php
@@ -21,7 +21,7 @@
  * Plugin Name: Affiliates
  * Plugin URI: http://www.itthinx.com/plugins/affiliates
  * Description: The Affiliates plugin provides the right tools to maintain a partner referral program.
- * Version: 2.15.10
+ * Version: 2.15.11
  * Author: itthinx
  * Author URI: http://www.itthinx.com
  * Donate-Link: http://www.itthinx.com
@@ -30,7 +30,7 @@
  * License: GPLv3
  */
 if ( !defined( 'AFFILIATES_CORE_VERSION' ) ) {
-	define( 'AFFILIATES_CORE_VERSION', '2.15.10' );
+	define( 'AFFILIATES_CORE_VERSION', '2.15.11' );
 	define( 'AFFILIATES_PLUGIN_NAME', 'affiliates' );
 	define( 'AFFILIATES_FILE', __FILE__ );
 	define( 'AFFILIATES_PLUGIN_BASENAME', plugin_basename( AFFILIATES_FILE ) );

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 == Affiliates - Changelog ==
 
+= 2.15.11 =
+* Fixed the affiliates_is_not_referred shortcode. Now when Direct referrals is enabled, the content is not displayed.
+
 = 2.15.10 =
 * Altered the hits table definition for MySQL 5.7.3 compatibility, see https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-3.html
 

--- a/lib/core/class-affiliates-shortcodes.php
+++ b/lib/core/class-affiliates-shortcodes.php
@@ -324,7 +324,9 @@ class Affiliates_Shortcodes {
 		$output = '';
 		require_once( 'class-affiliates-service.php' );
 		$affiliate_id = Affiliates_Service::get_referrer_id();
-		if ( !$affiliate_id ) {
+		
+		// it can not be an affiliate and direct doesn't count
+		if ( ( !$affiliate_id ) || ( $affiliate_id === affiliates_get_direct_id() ) ) {
 			$output .= $content;
 		}
 		return $output;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://www.itthinx.com/plugins/affiliates
 Tags: ads, AddToAny, AddThis, advertising, affiliate, affiliate marketing, affiliate plugin, affiliate tool, affiliates, contact form, contact form 7, downloads, e-commerce, Ecwid, Events Manager, Jigoshop, lead, link, marketing, money, partner, Pay per Click, PayPal, PPC, referral, referral links, referrer, sales, shopping cart, TheCartPress, track, transaction, WooCommerce, WP e-Commerce
 Requires at least: 4.0.0
 Tested up to: 4.6
-Stable tag: 2.15.10
+Stable tag: 2.15.11
 License: GPLv3
 
 The Affiliates system provides powerful tools to maintain an Affiliate Marketing Program.
@@ -340,6 +340,9 @@ See [Affiliates Screenshots](http://www.itthinx.com/plugins/affiliates/affiliate
 
 == Changelog ==
 
+= 2.15.11 =
+* Fixed the affiliates_is_not_referred shortcode. Now when Direct referrals is enabled, the content is not displayed.
+
 = 2.15.10 =
 * Altered the hits table definition for MySQL 5.7.3 compatibility, see https://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-3.html
 
@@ -390,5 +393,5 @@ See [Affiliates Screenshots](http://www.itthinx.com/plugins/affiliates/affiliate
 
 == Upgrade Notice ==
 
-= 2.15.10 =
-* This release fixes a compatibility issue with MySQL 5.7.3 and above.
+= 2.15.11 =
+* Fixed the affiliates_is_not_referred shortcode. Now when Direct referrals is enabled, the content is not displayed.


### PR DESCRIPTION
Fixed the affiliates_is_not_referred shortcode. Now when Direct
referrals is enabled, the content is not displayed.